### PR TITLE
fix gettimeofday ambiguity (not calling ACE function)

### DIFF
--- a/ComponentWebotsLidar/smartsoft/src/LaserTask.cc
+++ b/ComponentWebotsLidar/smartsoft/src/LaserTask.cc
@@ -152,7 +152,7 @@ int LaserTask::on_execute()
   {
     // time settings and update scan count
     timeval _receiveTime;
-    gettimeofday(&_receiveTime, 0);
+    ::gettimeofday(&_receiveTime, 0);
     scan.set_scan_time_stamp(CommBasicObjects::CommTimeStamp(_receiveTime));
     scan.set_scan_update_count(scanCount);
 


### PR DESCRIPTION
**Description**
There is an ambiguity here: sys and ACE have function gettimeofday. 
 Since the class is using the function from sys/time, one should explicitly say it to the compiler. 